### PR TITLE
KEYCLOAK-12281 Fix export/import for users that have custom credential algorithms with no salt

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
@@ -16,7 +16,7 @@ public class PasswordSecretData {
 
     @JsonCreator
     public PasswordSecretData(@JsonProperty("value") String value, @JsonProperty("salt") String salt) throws IOException {
-        if ("__SALT__".equals(salt)) {
+        if (salt == null || "__SALT__".equals(salt)) {
             this.value = value;
             this.salt = null;
         }

--- a/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
@@ -15,24 +15,20 @@ public class PasswordSecretData {
     private final byte[] salt;
 
     @JsonCreator
-    public PasswordSecretData(@JsonProperty("value") String value, @JsonProperty("salt") String salt) {
-        this(value, decodeSalt(salt));
+    public PasswordSecretData(@JsonProperty("value") String value, @JsonProperty("salt") String salt) throws IOException {
+        if ("__SALT__".equals(salt)) {
+            this.value = value;
+            this.salt = null;
+        }
+        else {
+            this.value = value;
+            this.salt = Base64.decode(salt);
+        }
     }
 
     public PasswordSecretData(String value, byte[] salt) {
         this.value = value;
         this.salt = salt;
-    }
-
-    private static byte[] decodeSalt(String salt) {
-        try {
-            return Base64.decode(salt);
-        } catch (IOException ioe) {
-            // Could happen under some corner cases that value is still placeholder value "__SALT__" . For example when importing JSON from
-            // previous version and using custom hash provider without salt support.
-            logger.tracef("Can't base64 decode the salt %s . Fallback to null salt", salt);
-            return null;
-        }
     }
 
     public String getValue() {


### PR DESCRIPTION
- do not swallow exception when decoding salt
